### PR TITLE
Added touch joystick for basic mobile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ https://theduckcow.itch.io/wheelie-big-and-small
 ## Credits
 
 - Godot Road Generator (also made by TheDuckCow) ([link](https://github.com/TheDuckCow/godot-road-generator))
+- Mobile touch input via Virtual-Joystick-Godot ([link](https://github.com/MarcoFazioRandom/Virtual-Joystick-Godot))
 - 8-bit Memphis Patterns Pack ([link](https://pixelbuddha.net/download/freebie/827-8-bit-memphis-patterns-pack))
 - Everything else created by the team, including shaders, models, and animations
 

--- a/wheelie-big-and-small/addons/virtual_joystick/plugin.cfg
+++ b/wheelie-big-and-small/addons/virtual_joystick/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Virtual Joystick"
+description="A simple virtual joystick for touchscreens, with useful options."
+author="Marco Fazio"
+version="1.0"
+script="virtual_joystick_plugin.gd"

--- a/wheelie-big-and-small/addons/virtual_joystick/previews/CoverPreview.svg
+++ b/wheelie-big-and-small/addons/virtual_joystick/previews/CoverPreview.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f9b9c7f316c84024da951c101fab4877055bcf8627eac3cbd5148a831635502
+size 298973

--- a/wheelie-big-and-small/addons/virtual_joystick/previews/CoverPreview.svg.import
+++ b/wheelie-big-and-small/addons/virtual_joystick/previews/CoverPreview.svg.import
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd7bc760159ad5874686c1845b8b74ae64f7d13cb25353841df7ca1b26da3f30
+size 900

--- a/wheelie-big-and-small/addons/virtual_joystick/previews/Logo.svg
+++ b/wheelie-big-and-small/addons/virtual_joystick/previews/Logo.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28fed4cb02780a365ca35445cf5c797b2f50823f2341344e4a065039d29aea1b
+size 4607

--- a/wheelie-big-and-small/addons/virtual_joystick/previews/Logo.svg.import
+++ b/wheelie-big-and-small/addons/virtual_joystick/previews/Logo.svg.import
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69fabb8cf516cc6ca81681d705ff9b52df9522ca4a35ecf1a4161f8288084634
+size 876

--- a/wheelie-big-and-small/addons/virtual_joystick/previews/ShowcasePreview.png
+++ b/wheelie-big-and-small/addons/virtual_joystick/previews/ShowcasePreview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e456c072e4a96e6e82c83c5f2c07a578d1200fd0308b775fbac817861f8c7d2
+size 191473

--- a/wheelie-big-and-small/addons/virtual_joystick/previews/ShowcasePreview.png.import
+++ b/wheelie-big-and-small/addons/virtual_joystick/previews/ShowcasePreview.png.import
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78468f3d0796cbe24c3686bb7f9ff00f3c257adcd303f1b28cb51707e66c3da2
+size 812

--- a/wheelie-big-and-small/addons/virtual_joystick/previews/joystick_icon.png
+++ b/wheelie-big-and-small/addons/virtual_joystick/previews/joystick_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44586ff3b33ea661d07a33c60c4b0621c696eafadae352f4a4ccf651e8493281
+size 22798

--- a/wheelie-big-and-small/addons/virtual_joystick/previews/joystick_icon.png.import
+++ b/wheelie-big-and-small/addons/virtual_joystick/previews/joystick_icon.png.import
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba45cf1ce13364cce3db02b2ccc8ff8252a774f70c0d7a023a9bbe07fa97e897
+size 806

--- a/wheelie-big-and-small/addons/virtual_joystick/test/player.gd
+++ b/wheelie-big-and-small/addons/virtual_joystick/test/player.gd
@@ -1,0 +1,23 @@
+extends Sprite2D
+
+@export var speed : float = 100
+
+@export var joystick_left : VirtualJoystick
+
+@export var joystick_right : VirtualJoystick
+
+var move_vector := Vector2.ZERO
+
+func _process(delta: float) -> void:
+	## Movement using the joystick output:
+#	if joystick_left and joystick_left.is_pressed:
+#		position += joystick_left.output * speed * delta
+	
+	## Movement using Input functions:
+	move_vector = Vector2.ZERO
+	move_vector = Input.get_vector("ui_left","ui_right","ui_up","ui_down")
+	position += move_vector * speed * delta
+	
+	# Rotation:
+	if joystick_right and joystick_right.is_pressed:
+		rotation = joystick_right.output.angle()

--- a/wheelie-big-and-small/addons/virtual_joystick/test/test.tscn
+++ b/wheelie-big-and-small/addons/virtual_joystick/test/test.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=4 format=3 uid="uid://bq2sqb1u1l5ve"]
+
+[ext_resource type="PackedScene" uid="uid://dmr0fcamx7t56" path="res://addons/virtual_joystick/virtual_joystick_scene.tscn" id="1_4k4lh"]
+[ext_resource type="Texture2D" uid="uid://kq1h264n0gxs" path="res://icon.svg" id="2_44wa8"]
+[ext_resource type="Script" path="res://addons/virtual_joystick/test/player.gd" id="3_dsmxw"]
+
+[node name="Test" type="Node2D"]
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="Virtual joystick left" parent="UI" instance=ExtResource("1_4k4lh")]
+
+[node name="Virtual joystick right" parent="UI" instance=ExtResource("1_4k4lh")]
+anchors_preset = 3
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -300.0
+offset_top = -300.0
+offset_right = 0.0
+offset_bottom = 0.0
+grow_horizontal = 0
+joystick_mode = 1
+use_input_actions = false
+
+[node name="Player" type="Sprite2D" parent="." node_paths=PackedStringArray("joystick_left", "joystick_right")]
+position = Vector2(600, 300)
+texture = ExtResource("2_44wa8")
+script = ExtResource("3_dsmxw")
+joystick_left = NodePath("../UI/Virtual joystick left")
+joystick_right = NodePath("../UI/Virtual joystick right")

--- a/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_base_outline.png
+++ b/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_base_outline.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b308196e94e22c189e618252871d9e3d8a88c18ceeb12116d8997498ce353392
+size 4827

--- a/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_base_outline.png.import
+++ b/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_base_outline.png.import
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:549fd4cde87c5f8e1ced278ab4f9c2476947697ad343c8b0edb496972a34dab1
+size 830

--- a/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_tip.png
+++ b/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_tip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f458139b5acc855e2c63aa9e2d9df309761d77866e08885518aa4d8236df225
+size 1780

--- a/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_tip.png.import
+++ b/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_tip.png.import
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ebea6d92b1aec848f2aa5818bc7f77c26da4e41e46f32bd94fcffe0fbd9b478
+size 803

--- a/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_tip_arrows.png
+++ b/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_tip_arrows.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:432cf700e57f6ef1f0127db088f7fc0da63fe1781bce44112c0021ef51ac7b83
+size 2229

--- a/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_tip_arrows.png.import
+++ b/wheelie-big-and-small/addons/virtual_joystick/textures/joystick_tip_arrows.png.import
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27863b18bea9ee747a7bdba4117d51cfac080c177d564a456a15439f406f1560
+size 824

--- a/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick.gd
+++ b/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick.gd
@@ -1,0 +1,174 @@
+class_name VirtualJoystick
+
+extends Control
+
+## A simple virtual joystick for touchscreens, with useful options.
+## Github: https://github.com/MarcoFazioRandom/Virtual-Joystick-Godot
+
+# EXPORTED VARIABLE
+
+## The color of the button when the joystick is pressed.
+@export var pressed_color := Color.GRAY
+
+## If the input is inside this range, the output is zero.
+@export_range(0, 200, 1) var deadzone_size : float = 10
+
+## The max distance the tip can reach.
+@export_range(0, 500, 1) var clampzone_size : float = 75
+
+enum Joystick_mode {
+	FIXED, ## The joystick doesn't move.
+	DYNAMIC, ## Every time the joystick area is pressed, the joystick position is set on the touched position.
+	FOLLOWING ## When the finger moves outside the joystick area, the joystick will follow it.
+}
+
+## If the joystick stays in the same position or appears on the touched position when touch is started
+@export var joystick_mode := Joystick_mode.FIXED
+
+enum Visibility_mode {
+	ALWAYS, ## Always visible
+	TOUCHSCREEN_ONLY, ## Visible on touch screens only
+	WHEN_TOUCHED ## Visible only when touched
+}
+
+## If the joystick is always visible, or is shown only if there is a touchscreen
+@export var visibility_mode := Visibility_mode.ALWAYS
+
+## If true, the joystick uses Input Actions (Project -> Project Settings -> Input Map)
+@export var use_input_actions := true
+
+@export var action_left := "ui_left"
+@export var action_right := "ui_right"
+@export var action_up := "ui_up"
+@export var action_down := "ui_down"
+
+# PUBLIC VARIABLES
+
+## If the joystick is receiving inputs.
+var is_pressed := false
+
+# The joystick output.
+var output := Vector2.ZERO
+
+# PRIVATE VARIABLES
+
+var _touch_index : int = -1
+
+@onready var _base := $Base
+@onready var _tip := $Base/Tip
+
+@onready var _base_default_position : Vector2 = _base.position
+@onready var _tip_default_position : Vector2 = _tip.position
+
+@onready var _default_color : Color = _tip.modulate
+
+# FUNCTIONS
+
+func _ready() -> void:
+	if ProjectSettings.get_setting("input_devices/pointing/emulate_mouse_from_touch"):
+		printerr("The Project Setting 'emulate_mouse_from_touch' should be set to False")
+	if not ProjectSettings.get_setting("input_devices/pointing/emulate_touch_from_mouse"):
+		printerr("The Project Setting 'emulate_touch_from_mouse' should be set to True")
+	
+	if not DisplayServer.is_touchscreen_available() and visibility_mode == Visibility_mode.TOUCHSCREEN_ONLY :
+		hide()
+	
+	if visibility_mode == Visibility_mode.WHEN_TOUCHED:
+		hide()
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventScreenTouch:
+		if event.pressed:
+			if _is_point_inside_joystick_area(event.position) and _touch_index == -1:
+				if joystick_mode == Joystick_mode.DYNAMIC or joystick_mode == Joystick_mode.FOLLOWING or (joystick_mode == Joystick_mode.FIXED and _is_point_inside_base(event.position)):
+					if joystick_mode == Joystick_mode.DYNAMIC or joystick_mode == Joystick_mode.FOLLOWING:
+						_move_base(event.position)
+					if visibility_mode == Visibility_mode.WHEN_TOUCHED:
+						show()
+					_touch_index = event.index
+					_tip.modulate = pressed_color
+					_update_joystick(event.position)
+					get_viewport().set_input_as_handled()
+		elif event.index == _touch_index:
+			_reset()
+			if visibility_mode == Visibility_mode.WHEN_TOUCHED:
+				hide()
+			get_viewport().set_input_as_handled()
+	elif event is InputEventScreenDrag:
+		if event.index == _touch_index:
+			_update_joystick(event.position)
+			get_viewport().set_input_as_handled()
+
+func _move_base(new_position: Vector2) -> void:
+	_base.global_position = new_position - _base.pivot_offset * get_global_transform_with_canvas().get_scale()
+
+func _move_tip(new_position: Vector2) -> void:
+	_tip.global_position = new_position - _tip.pivot_offset * _base.get_global_transform_with_canvas().get_scale()
+
+func _is_point_inside_joystick_area(point: Vector2) -> bool:
+	var x: bool = point.x >= global_position.x and point.x <= global_position.x + (size.x * get_global_transform_with_canvas().get_scale().x)
+	var y: bool = point.y >= global_position.y and point.y <= global_position.y + (size.y * get_global_transform_with_canvas().get_scale().y)
+	return x and y
+
+func _get_base_radius() -> Vector2:
+	return _base.size * _base.get_global_transform_with_canvas().get_scale() / 2
+
+func _is_point_inside_base(point: Vector2) -> bool:
+	var _base_radius = _get_base_radius()
+	var center : Vector2 = _base.global_position + _base_radius
+	var vector : Vector2 = point - center
+	if vector.length_squared() <= _base_radius.x * _base_radius.x:
+		return true
+	else:
+		return false
+
+func _update_joystick(touch_position: Vector2) -> void:
+	var _base_radius = _get_base_radius()
+	var center : Vector2 = _base.global_position + _base_radius
+	var vector : Vector2 = touch_position - center
+	vector = vector.limit_length(clampzone_size)
+	
+	if joystick_mode == Joystick_mode.FOLLOWING and touch_position.distance_to(center) > clampzone_size:
+		_move_base(touch_position - vector)
+	
+	_move_tip(center + vector)
+	
+	if vector.length_squared() > deadzone_size * deadzone_size:
+		is_pressed = true
+		output = (vector - (vector.normalized() * deadzone_size)) / (clampzone_size - deadzone_size)
+	else:
+		is_pressed = false
+		output = Vector2.ZERO
+	
+	if use_input_actions:
+		# Release actions
+		if output.x >= 0 and Input.is_action_pressed(action_left):
+			Input.action_release(action_left)
+		if output.x <= 0 and Input.is_action_pressed(action_right):
+			Input.action_release(action_right)
+		if output.y >= 0 and Input.is_action_pressed(action_up):
+			Input.action_release(action_up)
+		if output.y <= 0 and Input.is_action_pressed(action_down):
+			Input.action_release(action_down)
+		# Press actions
+		if output.x < 0:
+			Input.action_press(action_left, -output.x)
+		if output.x > 0:
+			Input.action_press(action_right, output.x)
+		if output.y < 0:
+			Input.action_press(action_up, -output.y)
+		if output.y > 0:
+			Input.action_press(action_down, output.y)
+
+func _reset():
+	is_pressed = false
+	output = Vector2.ZERO
+	_touch_index = -1
+	_tip.modulate = _default_color
+	_base.position = _base_default_position
+	_tip.position = _tip_default_position
+	# Release actions
+	if use_input_actions:
+		for action in [action_left, action_right, action_down, action_up]:
+			if Input.is_action_pressed(action):
+				Input.action_release(action)

--- a/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick_icon.png
+++ b/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44586ff3b33ea661d07a33c60c4b0621c696eafadae352f4a4ccf651e8493281
+size 22798

--- a/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick_icon.png.import
+++ b/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick_icon.png.import
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3d7843d9d3d4eacede8ceae5703c734ce7a7daa08f34e162dffab7aa9fd8d8d
+size 820

--- a/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick_instantiator.gd
+++ b/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick_instantiator.gd
@@ -1,0 +1,17 @@
+@tool
+extends Control
+
+var scene
+
+func _enter_tree():
+	scene = preload("res://addons/virtual_joystick/virtual_joystick_scene.tscn").instantiate()
+	add_child(scene)
+	
+	if ProjectSettings.get_setting("input_devices/pointing/emulate_mouse_from_touch"):
+		printerr("The Project Setting 'emulate_mouse_from_touch' should be set to False")
+	if not ProjectSettings.get_setting("input_devices/pointing/emulate_touch_from_mouse"):
+		printerr("The Project Setting 'emulate_touch_from_mouse' should be set to True")
+
+
+func _exit_tree():
+	scene.free()

--- a/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick_plugin.gd
+++ b/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick_plugin.gd
@@ -1,0 +1,10 @@
+@tool
+extends EditorPlugin
+
+
+func _enter_tree():
+	add_custom_type("Virtual Joystick", "Control", preload("virtual_joystick_instantiator.gd"), preload("virtual_joystick_icon.png"))
+
+
+func _exit_tree():
+	remove_custom_type("Virtual Joystick")

--- a/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick_scene.tscn
+++ b/wheelie-big-and-small/addons/virtual_joystick/virtual_joystick_scene.tscn
@@ -1,0 +1,53 @@
+[gd_scene load_steps=4 format=3 uid="uid://dmr0fcamx7t56"]
+
+[ext_resource type="Script" path="res://addons/virtual_joystick/virtual_joystick.gd" id="1_8x4dy"]
+[ext_resource type="Texture2D" uid="uid://bm30au8mjfc2f" path="res://addons/virtual_joystick/textures/joystick_base_outline.png" id="2_jhjs2"]
+[ext_resource type="Texture2D" uid="uid://dt13r06u87fib" path="res://addons/virtual_joystick/textures/joystick_tip_arrows.png" id="3_3etdg"]
+
+[node name="Virtual Joystick" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_8x4dy")
+pressed_color = Color(0.928984, 0.634131, 0.854984, 1)
+joystick_mode = 1
+visibility_mode = 2
+
+[node name="Base" type="TextureRect" parent="."]
+self_modulate = Color(1, 1, 1, 0.478431)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -100.0
+offset_right = 100.0
+offset_bottom = 100.0
+grow_horizontal = 2
+grow_vertical = 2
+pivot_offset = Vector2(100, 100)
+mouse_force_pass_scroll_events = false
+texture = ExtResource("2_jhjs2")
+stretch_mode = 5
+
+[node name="Tip" type="TextureRect" parent="Base"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -50.0
+offset_top = -50.0
+offset_right = 50.0
+offset_bottom = 50.0
+grow_horizontal = 2
+grow_vertical = 2
+pivot_offset = Vector2(50, 50)
+texture = ExtResource("3_3etdg")
+stretch_mode = 5

--- a/wheelie-big-and-small/project.godot
+++ b/wheelie-big-and-small/project.godot
@@ -29,7 +29,7 @@ project/assembly_name="Wheelie Big and Small"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/road-generator/plugin.cfg")
+enabled=PackedStringArray("res://addons/road-generator/plugin.cfg", "res://addons/virtual_joystick/plugin.cfg")
 
 [file_customization]
 

--- a/wheelie-big-and-small/ui/hud.gd
+++ b/wheelie-big-and-small/ui/hud.gd
@@ -8,6 +8,7 @@ extends Control
 @onready var debug_label := %debug
 @onready var record_label := %record
 @onready var checkpoint_timer_label = %checkpoint_timer
+@onready var joystick := %joystick
 
 var debug := false
 
@@ -25,6 +26,13 @@ func _ready() -> void:
 	else:
 		var parrow = record_label.get_parent_control()
 		parrow.hide()
+	
+	if not DisplayServer.is_touchscreen_available():
+		joystick.queue_free()
+	else:
+		# Without this, dying while tilted starts off with a
+		# tilt until pressing again
+		joystick.scene._reset()
 
 
 func _process(_delta: float) -> void:

--- a/wheelie-big-and-small/ui/hud.tscn
+++ b/wheelie-big-and-small/ui/hud.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=9 format=3 uid="uid://gtq4rtkbl2cq"]
+[gd_scene load_steps=10 format=3 uid="uid://gtq4rtkbl2cq"]
 
 [ext_resource type="Script" path="res://ui/hud.gd" id="1_s62w8"]
 [ext_resource type="Texture2D" uid="uid://dll13w4fo0ig5" path="res://ui/record_icon.png" id="2_17jxt"]
+[ext_resource type="Script" path="res://addons/virtual_joystick/virtual_joystick_instantiator.gd" id="3_yuu1o"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8clkx"]
 bg_color = Color(0.403922, 0.796078, 0.886275, 0)
@@ -146,3 +147,21 @@ theme_override_constants/outline_size = 12
 theme_override_font_sizes/font_size = 40
 text = "record "
 horizontal_alignment = 1
+
+[node name="mobile" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="joystick" type="Control" parent="mobile"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("3_yuu1o")


### PR DESCRIPTION
This isn't a perfect solution, given that the input signal is still all-or-nothing for any given direction. Additionally, at least on my Pixel 5a, some shading outputs on mobile are a bit odd. For instance:

- Overpass mesh looks entirely flat shaded, depsite being a simpler shader
- The texture on the road seems to be lost with shading
- Maybe it's really all textures on materials are lost? as also cars seem unshaded, but our 2-tone shader appears to work fine
- More generally, button sizes do not respect human interface guidelines, being too small.

All that being said, it's workable for now so will publish anyways. Basic mobile support is better than none!